### PR TITLE
Fix typo in README.md

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -124,7 +124,7 @@ Monitoring Agent and Backup Agent.  Adding the Monitoring and Backup Agents to o
         "monitoringVersions": [
             {
                 "hostname": "AGENT_HOSTNAME",
-                "logPath": "/var/log/mongodb-mms-automation/backup-agent.log",
+                "logPath": "/var/log/mongodb-mms-automation/monitoring-agent.log",
                 "logRotate": {
                     "sizeThresholdMB": 1000,
                     "timeThresholdHrs": 24


### PR DESCRIPTION
The log file for the monitoring agent was called "backup-agent.log"
