### PR TITLE
Add downloadBaseWindows to example

### DIFF
--- a/automation/example_configs/custom_versions.json
+++ b/automation/example_configs/custom_versions.json
@@ -1,6 +1,7 @@
 {
   "options": {
-    "downloadBase": "/var/lib/mongodb-mms-automation"
+    "downloadBase": "/var/lib/mongodb-mms-automation",
+    "downloadBaseWindows" : "%SystemDrive%\\MMSAutomation\\versions"
   },
   "mongoDbVersions": [
     {


### PR DESCRIPTION
MMS will show error and agents will do nothing (even on linux) if this option is not set.
